### PR TITLE
Start scheduler after X moment in time

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -221,7 +221,6 @@ func (schd *Scheduler) Del(name string) {
 	if _, ok := schd.tasks[name]; ok {
 		delete(schd.tasks, name)
 	}
-	return
 }
 
 // Lookup will find the specified task from the internal task list using the task ID provided.

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -15,7 +15,7 @@ func TestAdd(t *testing.T) {
 		id, err := scheduler.Add(&Task{
 			Interval: time.Duration(1 * time.Minute),
 			TaskFunc: func() error { return nil },
-			ErrFunc:  func(e error) { return },
+			ErrFunc:  func(e error) {},
 		})
 		if err != nil {
 			t.Errorf("Unexpected errors when scheduling a valid task - %s", err)
@@ -39,7 +39,7 @@ func TestAdd(t *testing.T) {
 	t.Run("Check for nil callback", func(t *testing.T) {
 		_, err := scheduler.Add(&Task{
 			Interval: time.Duration(1 * time.Minute),
-			ErrFunc:  func(e error) { return },
+			ErrFunc:  func(e error) {},
 		})
 		if err == nil {
 			t.Errorf("Unexpected success when scheduling an invalid task - %s", err)
@@ -49,7 +49,7 @@ func TestAdd(t *testing.T) {
 	t.Run("Check for nil interval", func(t *testing.T) {
 		_, err := scheduler.Add(&Task{
 			TaskFunc: func() error { return nil },
-			ErrFunc:  func(e error) { return },
+			ErrFunc:  func(e error) {},
 		})
 		if err == nil {
 			t.Errorf("Unexpected success when scheduling an invalid task - %s", err)
@@ -72,7 +72,7 @@ func TestScheduler(t *testing.T) {
 				doneCh <- struct{}{}
 				return nil
 			},
-			ErrFunc: func(e error) { return },
+			ErrFunc: func(e error) {},
 		})
 		if err != nil {
 			t.Errorf("Unexpected errors when scheduling a valid task - %s", err)
@@ -105,7 +105,7 @@ func TestScheduler(t *testing.T) {
 				doneCh <- struct{}{}
 				return nil
 			},
-			ErrFunc: func(e error) { return },
+			ErrFunc: func(e error) {},
 		})
 		if err != nil {
 			t.Errorf("Unexpected errors when scheduling a valid task - %s", err)
@@ -135,7 +135,7 @@ func TestScheduler(t *testing.T) {
 				doneCh <- struct{}{}
 				return nil
 			},
-			ErrFunc: func(e error) { return },
+			ErrFunc: func(e error) {},
 		})
 		if err != nil {
 			t.Errorf("Unexpected errors when scheduling a valid task - %s", err)
@@ -174,7 +174,7 @@ func TestScheduler(t *testing.T) {
 				doneCh <- struct{}{}
 				return nil
 			},
-			ErrFunc: func(e error) { return },
+			ErrFunc: func(e error) {},
 		})
 		if err != nil {
 			t.Errorf("Unexpected errors when scheduling a valid task - %s", err)


### PR DESCRIPTION
# Description

This pull request adds the ability to tell the scheduler not to schedule a task until after X point in time. This is useful for when you want to schedule something to start in the future but not now. I.E. I want to start an email task every Sunday, I could start the scheduler by waiting X days until next Sunday and give the task an interval of 7 days.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] Small and simple changes (Tech Debt, Doc updates, Adding tests, etc.)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, ensuring GoDoc readability and clarity in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have added tests that ensure my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules

If checklist items are unchecked please explain.

No downstream dependencies.