### PR TITLE
Adding delay only for late starters

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -238,7 +238,11 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 	t.id = id
 	schd.tasks[t.id] = t
 
-	go schd.scheduleTask(t)
+	if time.Until(t.StartAfter) > time.Duration(0) {
+		go schd.scheduleTask(t)
+		return nil
+	}
+	schd.scheduleTask(t)
 	return nil
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -238,11 +238,11 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 	t.id = id
 	schd.tasks[t.id] = t
 
-	if time.Until(t.StartAfter) > time.Duration(0) {
-		go schd.scheduleTask(t)
+	if t.StartAfter.IsZero() {
+		schd.scheduleTask(t)
 		return nil
 	}
-	schd.scheduleTask(t)
+	go schd.scheduleTask(t)
 	return nil
 }
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR fixes an interesting issue reported by users where quick scheduling and removal can cause timers to remain. This moves the schedule into the hot path only if StartAfter is 0.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, ensuring GoDoc readability and clarity in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have added tests that ensure my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules

If checklist items are unchecked please explain.
