### PR TITLE
Copying Map

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -292,7 +292,11 @@ func (schd *Scheduler) Lookup(name string) (*Task, error) {
 func (schd *Scheduler) Tasks() map[string]*Task {
 	schd.RLock()
 	defer schd.RUnlock()
-	return schd.tasks
+	m := make(map[string]*Task)
+	for k, v := range schd.tasks {
+		m[k] = v
+	}
+	return m
 }
 
 // Stop is used to unschedule and delete all tasks owned by the scheduler instance.


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This change will create a copy of the task map and return it to users rather than returning the task map directly. Since maps in Go are essentially pointers, if a user is iterating over the returned map while it's being written to (scheduling, deleting, etc.) then there is a possibility of a race condition.

This change will prevent that by returning a copy of the map.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, ensuring GoDoc readability and clarity in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have added tests that ensure my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules

If checklist items are unchecked please explain.
