### PR TITLE
Optimize Scheduling when using StartAfter

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -265,11 +265,7 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 	t.id = id
 	schd.tasks[t.id] = t
 
-	if t.StartAfter.IsZero() {
-		schd.scheduleTask(t)
-		return nil
-	}
-	go schd.scheduleTask(t)
+	schd.scheduleTask(t)
 	return nil
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -334,7 +334,13 @@ func (schd *Scheduler) Stop() {
 // time specified.
 func (schd *Scheduler) scheduleTask(t *Task) {
 	_ = time.AfterFunc(time.Until(t.StartAfter), func() {
-		if t.ctx.Err() != nil {
+		var err error
+
+		// Verify if task has been cancelled before scheduling
+		t.safeOps(func() {
+			err = t.ctx.Err()
+		})
+		if err != nil {
 			// Task has been cancelled, do not schedule
 			return
 		}

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -313,6 +313,28 @@ func TestTaskExecution(t *testing.T) {
 	}
 	tt = append(tt, tc6)
 
+	// Verify that StartAfter time is respected
+	tc7 := ExecutionTestCase{
+		name:      "Verify StartAfter time is respected",
+		callsFunc: true,
+	}
+	tc7StartAfter := time.Now().Add(time.Duration(5 * time.Second))
+	tc7.ctx, tc7.cancel = context.WithCancel(context.Background())
+	tc7.task = &Task{
+		Interval:    time.Duration(1 * time.Second),
+		StartAfter:  tc7StartAfter,
+		TaskContext: TaskContext{Context: tc7.ctx},
+		FuncWithTaskContext: func(taskCtx TaskContext) error {
+			if time.Now().Before(tc7StartAfter) {
+				t.Errorf("Task should not have been called before StartAfter time")
+				return nil
+			}
+			tc7.cancel()
+			return nil
+		},
+	}
+	tt = append(tt, tc7)
+
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			var err error


### PR DESCRIPTION
This PR optimizes how tasks are scheduled when using the `StartAfter` option. Previously, the scheduler would create a goroutine when using `StartAfter` and wait for a response from `time.After()`. This change uses `time.AfterFunc()` to create a one-off task that then schedules another task.

Some data from benchmarks.

Before:
```
$ go test -run=Benchmark -bench ./...
goos: darwin
goarch: amd64
pkg: github.com/madflojo/tasks
cpu: Intel(R) Core(TM) i5-6360U CPU @ 2.00GHz
BenchmarkTasks/Adding_a_scheduler-4             219752        5418 ns/op       722 B/op       10 allocs/op
BenchmarkTasks/Looking_up_a_scheduled_task-4          35873827          32.75 ns/op        0 B/op        0 allocs/op
PASS
ok    github.com/madflojo/tasks 2.955s
```

After:
```
$ go test -run=Benchmark -bench ./...
goos: darwin
goarch: amd64
pkg: github.com/madflojo/tasks
cpu: Intel(R) Core(TM) i5-6360U CPU @ 2.00GHz
BenchmarkTasks/Adding_a_scheduler-4             635785        2245 ns/op       500 B/op        8 allocs/op
BenchmarkTasks/Looking_up_a_scheduled_task-4          35625927          32.69 ns/op        0 B/op        0 allocs/op
PASS
ok    github.com/madflojo/tasks 3.794s
```