### PR TITLE
fix(scheduler): stop deleted tasks from rescheduling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: tests
+permissions:
+  contents: read
 
 on:
   push:
@@ -10,28 +12,24 @@ on:
   pull_request:
 
 jobs:
-
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.18
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-    - name: Install cover
-      run: go get golang.org/x/tools/cmd/cover
+      - name: Test
+        run: go test -race -v -covermode=atomic -coverprofile=coverage.out ./...
 
-    - name: Install goveralls
-      run: go get -u github.com/mattn/goveralls
-
-    - name: Test
-      run: go test -race -v -covermode=atomic -coverprofile=coverage.out ./...
-
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v4.0.1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        slug: madflojo/tasks
+      - name: Upload coverage reports to Codecov
+        if: ${{ hashFiles('coverage.out') != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.out
+          flags: unittests
+          name: tasks
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,10 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           go-version-file: go.mod
 
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ hashFiles('coverage.out') != '' }}
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           files: coverage.out
           flags: unittests

--- a/tasks.go
+++ b/tasks.go
@@ -288,26 +288,26 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 // Del will unschedule the specified task and remove it from the task list. Deletion will prevent future invocations of
 // a task, but not interrupt a trigged task.
 func (schd *Scheduler) Del(name string) {
-	// Grab task from task list
-	t, err := schd.Lookup(name)
-	if err != nil {
+	schd.Lock()
+	t, ok := schd.tasks[name]
+	if !ok {
+		schd.Unlock()
 		return
 	}
+	delete(schd.tasks, name)
+	schd.Unlock()
 
 	// Stop the task
-	defer t.cancel()
+	if t.cancel != nil {
+		t.cancel()
+	}
 
 	t.Lock()
 	defer t.Unlock()
 
 	if t.timer != nil {
-		defer t.timer.Stop()
+		t.timer.Stop()
 	}
-
-	// Remove from task list
-	schd.Lock()
-	defer schd.Unlock()
-	delete(schd.tasks, name)
 }
 
 // Lookup will find the specified task from the internal task list using the task ID provided.
@@ -403,6 +403,9 @@ func (schd *Scheduler) execTask(t *Task) {
 	// Reschedule task for next execution
 	if !t.RunOnce {
 		t.safeOps(func() {
+			if t.ctx.Err() != nil || t.timer == nil {
+				return
+			}
 			t.timer.Reset(t.Interval)
 		})
 	}

--- a/tasks.go
+++ b/tasks.go
@@ -286,7 +286,7 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 }
 
 // Del will unschedule the specified task and remove it from the task list. Deletion will prevent future invocations of
-// a task, but not interrupt a trigged task.
+// a task, but not interrupt a triggered task.
 func (schd *Scheduler) Del(name string) {
 	schd.Lock()
 	t, ok := schd.tasks[name]

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -681,6 +682,64 @@ func TestSchedulerDoesntRun(t *testing.T) {
 				}
 				t.Errorf("Scheduler failed to execute the scheduled tasks %d run within 2 seconds", i)
 			}
+		}
+	})
+
+	t.Run("Verify Tasks Dont run when Deleted during execution", func(t *testing.T) {
+		startedCtx, started := context.WithCancel(context.Background())
+		releaseCtx, release := context.WithCancel(context.Background())
+		finishedCtx, finished := context.WithCancel(context.Background())
+		postDeleteCtx, postDelete := context.WithCancel(context.Background())
+
+		var runCount int32
+		var deleted uint32
+
+		id, err := scheduler.Add(&Task{
+			Interval: time.Duration(100 * time.Millisecond),
+			TaskFunc: func() error {
+				currentRun := atomic.AddInt32(&runCount, 1)
+
+				if currentRun == 1 {
+					started()
+					<-releaseCtx.Done()
+					finished()
+					return nil
+				}
+
+				if atomic.LoadUint32(&deleted) == 1 {
+					postDelete()
+				}
+
+				t.Errorf("task executed after delete, run=%d", currentRun)
+				return nil
+			},
+			ErrFunc: func(_ error) {},
+		})
+		if err != nil {
+			t.Fatalf("Unexpected errors when scheduling a valid task - %s", err)
+		}
+		defer scheduler.Del(id)
+
+		select {
+		case <-startedCtx.Done():
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Scheduler failed to start the scheduled task")
+		}
+
+		atomic.StoreUint32(&deleted, 1)
+		scheduler.Del(id)
+		release()
+
+		select {
+		case <-finishedCtx.Done():
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Task did not finish after delete")
+		}
+
+		select {
+		case <-postDeleteCtx.Done():
+			t.Fatalf("Task executed again after delete")
+		case <-time.After(350 * time.Millisecond):
 		}
 	})
 }

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -689,7 +689,8 @@ func TestSchedulerDoesntRun(t *testing.T) {
 		startedCtx, started := context.WithCancel(context.Background())
 		releaseCtx, release := context.WithCancel(context.Background())
 		finishedCtx, finished := context.WithCancel(context.Background())
-		postDeleteCtx, postDelete := context.WithCancel(context.Background())
+		errCtx, errCancel := context.WithCancel(context.Background())
+		defer errCancel()
 
 		var runCount int32
 		var deleted uint32
@@ -707,13 +708,14 @@ func TestSchedulerDoesntRun(t *testing.T) {
 				}
 
 				if atomic.LoadUint32(&deleted) == 1 {
-					postDelete()
+					return fmt.Errorf("task executed after delete, run=%d", currentRun)
 				}
 
-				t.Errorf("task executed after delete, run=%d", currentRun)
 				return nil
 			},
-			ErrFunc: func(_ error) {},
+			ErrFunc: func(_ error) {
+				errCancel()
+			},
 		})
 		if err != nil {
 			t.Fatalf("Unexpected errors when scheduling a valid task - %s", err)
@@ -737,7 +739,7 @@ func TestSchedulerDoesntRun(t *testing.T) {
 		}
 
 		select {
-		case <-postDeleteCtx.Done():
+		case <-errCtx.Done():
 			t.Fatalf("Task executed again after delete")
 		case <-time.After(350 * time.Millisecond):
 		}


### PR DESCRIPTION
## Summary
Fix scheduler deletion so recurring tasks do not rearm after cancellation, refresh the CI workflow, and bring the public docs back in line with the actual API.

## Changes
- delete tasks directly from the scheduler map and stop the canonical task instance
- skip timer reset when a task context has already been canceled
- add a regression test for deleting a recurring task while its task function is still running
- update the GitHub Actions workflow to current checkout/setup-go/codecov actions and simplify coverage setup
- fix broken documentation examples and document `RunSingleInstance`, task-context callbacks, and `AddWithID`

## Rationale
The delete path previously operated on a cloned task, which made cancellation less authoritative and allowed recurring timers to be rearmed after deletion. The workflow refresh removes stale setup, and the docs update closes the gap between the implemented API and the published examples.

## Risk & Impact
- Breaking changes: no
- Performance/Security: no material impact; behavior is safer around task deletion and scheduling, and docs/examples are now accurate
