### PR TITLE
docs(tasks): fix and expand scheduler documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ and flexible control over when tasks are executed.
 - **Flexible Task Intervals**: Tasks uses the `time.Duration` type to specify intervals, offering a simple interface and flexible control over task execution timing.
 - **Delayed Task Start**: Schedule tasks to start at a later time by specifying a start time, allowing for greater control over task execution.
 - **One-Time Tasks**: Schedule tasks to run only once by setting the `RunOnce` flag, ideal for single-use tasks or one-time actions.
+- **Single-Instance Tasks**: Prevent overlapping runs by setting `RunSingleInstance`, which skips a run if the previous invocation is still executing.
+- **Task Context Support**: Pass user-defined context and task metadata into callbacks with `FuncWithTaskContext`, `ErrFuncWithTaskContext`, and `TaskContext.ID()`.
 - **Custom Error Handling**: Define a custom error handling function to handle errors returned by tasks, enabling tailored error handling logic.
+- **Custom Task IDs**: Provide your own task IDs with `AddWithID` when you need deterministic identifiers.
 
 ## Usage
 
@@ -40,6 +43,7 @@ id, err := scheduler.Add(&tasks.Task{
   Interval: 30 * time.Second,
   TaskFunc: func() error {
     // Put your logic here
+    return nil
   },
 })
 if err != nil {
@@ -59,6 +63,7 @@ id, err := scheduler.Add(&tasks.Task{
   StartAfter: time.Now().Add(30 * (24 * time.Hour)),
   TaskFunc: func() error {
     // Put your logic here
+    return nil
   },
 })
 if err != nil {
@@ -78,6 +83,7 @@ id, err := scheduler.Add(&tasks.Task{
   RunOnce:  true,
   TaskFunc: func() error {
     // Put your logic here
+    return nil
   },
 })
 if err != nil {
@@ -97,9 +103,68 @@ id, err := scheduler.Add(&tasks.Task{
   Interval: 30 * time.Second,
   TaskFunc: func() error {
     // Put your logic here
+    return nil
   },
   ErrFunc: func(e error) {
     log.Printf("An error occurred when executing task %s - %s", id, e)
+  },
+})
+if err != nil {
+  // Do Stuff
+}
+```
+
+### Single-Instance Tasks
+
+Use `RunSingleInstance` when a task might take longer than its interval and overlapping executions should be skipped.
+
+```go
+id, err := scheduler.Add(&tasks.Task{
+  Interval:          30 * time.Second,
+  RunSingleInstance: true,
+  TaskFunc: func() error {
+    // Put your logic here
+    return nil
+  },
+})
+if err != nil {
+  // Do Stuff
+}
+```
+
+### Task Context
+
+Use the context-aware callbacks when you want to pass a user-defined context into task execution and error handling.
+
+```go
+ctx := context.Background()
+
+id, err := scheduler.Add(&tasks.Task{
+  Interval:    30 * time.Second,
+  TaskContext: tasks.TaskContext{Context: ctx},
+  FuncWithTaskContext: func(taskCtx tasks.TaskContext) error {
+    log.Printf("running task %s", taskCtx.ID())
+    return nil
+  },
+  ErrFuncWithTaskContext: func(taskCtx tasks.TaskContext, err error) {
+    log.Printf("task %s failed: %v", taskCtx.ID(), err)
+  },
+})
+if err != nil {
+  // Do Stuff
+}
+```
+
+### Custom Task IDs
+
+Use `AddWithID` when you want to provide your own stable identifier for a task.
+
+```go
+err := scheduler.AddWithID("nightly-report", &tasks.Task{
+  Interval: time.Hour,
+  TaskFunc: func() error {
+    // Put your logic here
+    return nil
   },
 })
 if err != nil {

--- a/tasks.go
+++ b/tasks.go
@@ -23,6 +23,7 @@ Below is an example of starting the scheduler and registering a new task that ru
 		Interval: time.Duration(30 * time.Second),
 		TaskFunc: func() error {
 			// Put your logic here
+			return nil
 		},
 	})
 	if err != nil {
@@ -38,6 +39,7 @@ a certain time. The below example shows this in practice.
 		StartAfter: time.Now().Add(30 * (24 * time.Hour)),
 		TaskFunc: func() error {
 			// Put your logic here
+			return nil
 		},
 	})
 	if err != nil {
@@ -49,10 +51,11 @@ waiting for 60 seconds.
 
 	// Add a one time only task for 60 seconds from now
 	id, err := scheduler.Add(&tasks.Task{
-		Interval: time.Duration(60 * time.Second)
+		Interval: time.Duration(60 * time.Second),
 		RunOnce:  true,
 		TaskFunc: func() error {
 			// Put your logic here
+			return nil
 		},
 	})
 	if err != nil {
@@ -68,9 +71,58 @@ error occurs.
 		Interval: time.Duration(30 * time.Second),
 		TaskFunc: func() error {
 			// Put your logic here
-		}(),
+			return nil
+		},
 		ErrFunc: func(e error) {
 			log.Printf("An error occurred when executing task %s - %s", id, e)
+		},
+	})
+	if err != nil {
+		// Do Stuff
+	}
+
+Tasks also supports single-instance execution for tasks that should never overlap.
+
+	// Add a single-instance task
+	id, err := scheduler.Add(&tasks.Task{
+		Interval:          time.Duration(30 * time.Second),
+		RunSingleInstance: true,
+		TaskFunc: func() error {
+			// Put your logic here
+			return nil
+		},
+	})
+	if err != nil {
+		// Do Stuff
+	}
+
+When you need access to a user-defined context or the task ID during execution, use the context-aware callbacks.
+
+	// Add a task with context-aware callbacks
+	id, err := scheduler.Add(&tasks.Task{
+		Interval: time.Duration(30 * time.Second),
+		TaskContext: tasks.TaskContext{
+			Context: context.Background(),
+		},
+		FuncWithTaskContext: func(taskCtx tasks.TaskContext) error {
+			log.Printf("running task %s", taskCtx.ID())
+			return nil
+		},
+		ErrFuncWithTaskContext: func(taskCtx tasks.TaskContext, err error) {
+			log.Printf("task %s failed: %s", taskCtx.ID(), err)
+		},
+	})
+	if err != nil {
+		// Do Stuff
+	}
+
+If you need a deterministic identifier, tasks can also be added with a custom ID.
+
+	err = scheduler.AddWithID("nightly-report", &tasks.Task{
+		Interval: time.Duration(1 * time.Hour),
+		TaskFunc: func() error {
+			// Put your logic here
+			return nil
 		},
 	})
 	if err != nil {
@@ -215,10 +267,11 @@ func New() *Scheduler {
 //		Interval: time.Duration(30 * time.Second),
 //		TaskFunc: func() error {
 //			// Put your logic here
-//		}(),
+//			return nil
+//		},
 //		ErrFunc: func(err error) {
 //			// Put custom error handling here
-//		}(),
+//		},
 //	})
 //	if err != nil {
 //		// Do stuff
@@ -242,10 +295,11 @@ func (schd *Scheduler) Add(t *Task) (string, error) {
 //		Interval: time.Duration(30 * time.Second),
 //		TaskFunc: func() error {
 //			// Put your logic here
-//		}(),
+//			return nil
+//		},
 //		ErrFunc: func(err error) {
 //			// Put custom error handling here
-//		}(),
+//		},
 //	})
 //	if err != nil {
 //		// Do stuff


### PR DESCRIPTION
## Summary
Update the public scheduler docs so they match the actual API and stop showing broken examples.

## Changes
- fix README code samples so task callbacks return `nil`
- document `RunSingleInstance`, task-context callbacks, and `AddWithID` in the README
- correct the package-level examples in `tasks.go`
- add package-doc examples for single-instance tasks, context-aware callbacks, and custom task IDs

## Rationale
The previous docs described the package at a high level but missed supported features and included examples that were not compile-ready. This makes the README and generated Go docs line up with the current implementation.

## Risk & Impact
- Breaking changes: no
- Performance/Security: none; documentation-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced documentation with examples demonstrating single-instance task execution to prevent overlapping runs.
  * Added guidance on context-aware callbacks and accessing task context information.
  * Included examples for assigning custom task identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->