### PR TITLE
fix(scheduler): harden task validation and add repo make targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,16 @@ Bugs, Proposals, & Feature Requests are all welcome. To get started, please open
 ## Contributing
 
 Contributions are always appreciated, please try to maintain usage contracts. If you are unsure, please open an issue to discuss.
+
+## Local Verification
+
+This repository includes a `Makefile` to keep local checks predictable:
+
+- `make build` builds the package.
+- `make tests` runs the test suite with the race detector enabled.
+- `make benchmarks` runs the benchmark suite.
+- `make coverage` writes coverage output to `coverage.out`.
+- `make lint` runs `golangci-lint` when it is installed.
+- `make format` applies `gofmt` and, when available, `golines`.
+
+Please run `make tests` before opening a pull request. If you have `golangci-lint` installed locally, run `make lint` too.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: all clean tests lint build format benchmarks coverage
+
+all: build tests lint
+
+tests:
+	@echo "Running tests..."
+	go test -race ./...
+
+benchmarks:
+	@echo "Running benchmarks..."
+	go test -race -run=^$$ -bench=. -benchmem ./...
+
+build:
+	@echo "Building package..."
+	go build ./...
+
+format:
+	@echo "Formatting code..."
+	gofmt -s -w .
+	@if command -v golines >/dev/null 2>&1; then \
+		golines -w .; \
+	else \
+		echo "golines not installed, skipping line wrapping"; \
+	fi
+
+lint:
+	@echo "Linting code..."
+	@if command -v golangci-lint >/dev/null 2>&1; then \
+		golangci-lint run ./...; \
+	else \
+		echo "golangci-lint not installed, skipping lint"; \
+	fi
+
+coverage:
+	@echo "Running coverage..."
+	go test -race -coverprofile=coverage.out ./...
+
+clean:
+	@echo "Cleaning build artifacts..."
+	@find . -type f -name "*.test" -delete
+	@find . -type f -name "coverage.out" -delete
+	@find . -type f -name "coverage.html" -delete
+	@rm -rf bin/

--- a/README.md
+++ b/README.md
@@ -177,3 +177,14 @@ For more details on usage, see the [GoDoc](https://pkg.go.dev/github.com/madfloj
 ## Contributing
 
 Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+
+## Development
+
+Common local workflows are available through the repository `Makefile`:
+
+- `make build`
+- `make tests`
+- `make benchmarks`
+- `make coverage`
+- `make lint`
+- `make format`

--- a/tasks.go
+++ b/tasks.go
@@ -247,6 +247,9 @@ type Scheduler struct {
 }
 
 var (
+	// ErrNilTask is returned when a nil task is provided to Add or AddWithID.
+	ErrNilTask = fmt.Errorf("task cannot be nil")
+
 	// ErrIDInUse is returned when a Task ID is specified but already used.
 	ErrIDInUse = fmt.Errorf("ID already used")
 )
@@ -282,7 +285,10 @@ func (schd *Scheduler) Add(t *Task) (string, error) {
 	if err == ErrIDInUse {
 		return schd.Add(t)
 	}
-	return id.String(), err
+	if err != nil {
+		return "", err
+	}
+	return id.String(), nil
 }
 
 // AddWithID will add a task with an ID to the task list and schedule it. It will return an error if the ID is in-use.
@@ -305,6 +311,10 @@ func (schd *Scheduler) Add(t *Task) (string, error) {
 //		// Do stuff
 //	}
 func (schd *Scheduler) AddWithID(id string, t *Task) error {
+	if t == nil {
+		return ErrNilTask
+	}
+
 	// Check if TaskFunc is nil before doing anything
 	if t.TaskFunc == nil && t.FuncWithTaskContext == nil {
 		return fmt.Errorf("task function cannot be nil")
@@ -358,8 +368,8 @@ func (schd *Scheduler) Del(name string) {
 
 // Lookup will find the specified task from the internal task list using the task ID provided.
 //
-// The returned task should be treated as read-only, and not modified outside of this package. Doing so, may cause
-// panics.
+// The returned task is a copy of the scheduled task configuration. Scheduler-owned runtime state is intentionally
+// excluded from the returned task.
 func (schd *Scheduler) Lookup(name string) (*Task, error) {
 	schd.RLock()
 	defer schd.RUnlock()
@@ -372,8 +382,8 @@ func (schd *Scheduler) Lookup(name string) (*Task, error) {
 
 // Tasks is used to return a copy of the internal tasks map.
 //
-// The returned task should be treated as read-only, and not modified outside of this package. Doing so, may cause
-// panics.
+// Each task in the returned map is a copy of the scheduled task configuration. Scheduler-owned runtime state is
+// intentionally excluded from the returned tasks.
 func (schd *Scheduler) Tasks() map[string]*Task {
 	schd.RLock()
 	defer schd.RUnlock()

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -404,6 +404,29 @@ func TestAdd(t *testing.T) {
 	scheduler := New()
 	defer scheduler.Stop()
 
+	t.Run("Add a nil task returns ErrNilTask", func(t *testing.T) {
+		id, err := scheduler.Add(nil)
+		if err != ErrNilTask {
+			t.Fatalf("expected ErrNilTask, got %v", err)
+		}
+		if id != "" {
+			t.Fatalf("expected empty ID for nil task, got %q", id)
+		}
+		if _, lookupErr := scheduler.Lookup(id); lookupErr == nil {
+			t.Fatalf("nil task should not be added to the scheduler")
+		}
+	})
+
+	t.Run("AddWithID a nil task returns ErrNilTask", func(t *testing.T) {
+		err := scheduler.AddWithID("nil-task", nil)
+		if err != ErrNilTask {
+			t.Fatalf("expected ErrNilTask, got %v", err)
+		}
+		if _, lookupErr := scheduler.Lookup("nil-task"); lookupErr == nil {
+			t.Fatalf("nil task should not be added to the scheduler")
+		}
+	})
+
 	t.Run("Add a valid task and look it up", func(t *testing.T) {
 		id, err := scheduler.Add(&Task{
 			Interval: time.Duration(1 * time.Minute),
@@ -506,7 +529,10 @@ func TestAdd(t *testing.T) {
 			t.Errorf("expected caller task id to remain empty, got %q", task.id)
 		}
 		if task.TaskContext.ID() != "" {
-			t.Errorf("expected caller task context id to remain empty, got %q", task.TaskContext.ID())
+			t.Errorf(
+				"expected caller task context id to remain empty, got %q",
+				task.TaskContext.ID(),
+			)
 		}
 		if task.ctx != nil {
 			t.Errorf("expected caller task ctx to remain nil")
@@ -537,7 +563,10 @@ func TestAdd(t *testing.T) {
 			t.Fatalf("expected source task id to be omitted, got %q", sourceTask.id)
 		}
 		if sourceTask.TaskContext.ID() != "" {
-			t.Fatalf("expected source task context id to be omitted, got %q", sourceTask.TaskContext.ID())
+			t.Fatalf(
+				"expected source task context id to be omitted, got %q",
+				sourceTask.TaskContext.ID(),
+			)
 		}
 		if sourceTask.ctx != nil {
 			t.Fatalf("expected source task context to be omitted")
@@ -607,7 +636,10 @@ func TestScheduler(t *testing.T) {
 			case <-doneCh:
 				continue
 			case <-time.After(2 * time.Second):
-				t.Errorf("Scheduler failed to execute the scheduled tasks %d run within 2 seconds", i)
+				t.Errorf(
+					"Scheduler failed to execute the scheduled tasks %d run within 2 seconds",
+					i,
+				)
 			}
 		}
 	})
@@ -644,7 +676,10 @@ func TestScheduler(t *testing.T) {
 			case <-doneCh:
 				continue
 			case <-time.After(2 * time.Second):
-				t.Errorf("Scheduler failed to execute the scheduled tasks %d run within 2 seconds", i)
+				t.Errorf(
+					"Scheduler failed to execute the scheduled tasks %d run within 2 seconds",
+					i,
+				)
 			}
 		}
 	})
@@ -675,7 +710,11 @@ func TestScheduler(t *testing.T) {
 		select {
 		case <-doneCh:
 			if time.Now().Before(sa) {
-				t.Errorf("Task executed before the defined start time now %s, supposed to be %s", time.Now().String(), sa.String())
+				t.Errorf(
+					"Task executed before the defined start time now %s, supposed to be %s",
+					time.Now().String(),
+					sa.String(),
+				)
 			}
 			return
 		case <-time.After(15 * time.Second):
@@ -756,7 +795,10 @@ func TestSchedulerDoesntRun(t *testing.T) {
 				if i > 2 {
 					return
 				}
-				t.Errorf("Scheduler failed to execute the scheduled tasks %d run within 2 seconds", i)
+				t.Errorf(
+					"Scheduler failed to execute the scheduled tasks %d run within 2 seconds",
+					i,
+				)
 			}
 		}
 	})
@@ -858,7 +900,10 @@ func TestSchedulerExtras(t *testing.T) {
 				if i == 1 {
 					return
 				}
-				t.Errorf("Scheduler failed to execute the scheduled tasks %d run within 2 seconds", i)
+				t.Errorf(
+					"Scheduler failed to execute the scheduled tasks %d run within 2 seconds",
+					i,
+				)
 			}
 		}
 	})


### PR DESCRIPTION
## Summary
Tightens the scheduler's validation behavior and makes local verification easier to run consistently.

## Changes
- add `ErrNilTask` and reject nil task input without returning a misleading task ID
- cover the new validation behavior in tests and keep the scheduler docs aligned with the clone-based API
- add a repository `Makefile` for build, test, lint, coverage, benchmark, and formatting workflows
- document the repository `Makefile` in `README.md` and `CONTRIBUTING.md`

## Rationale
The review surfaced a small API footgun around nil task input and a tooling gap where the documented `make tests` flow did not exist. This closes both loops.

## Risk & Impact
- Breaking changes: low; invalid `Add(nil)` calls now return `ErrNilTask` instead of panicking
- Performance/Security: low; benchmarks now run with `-race`, so they are slower but safer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added development workflow guide in CONTRIBUTING.md with standardized build commands.
  * Added Development section to README.md documenting common local repository commands.

* **Bug Fixes**
  * Added validation to reject nil tasks when adding to the scheduler, preventing invalid state.
  * Improved error handling in task addition to correctly propagate validation errors.

* **Tests**
  * Added tests validating proper rejection of nil tasks during scheduling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->