### PR TITLE
ci: pin action updates and fix lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,7 @@
 name: lint
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -12,27 +15,23 @@ jobs:
     name: golangci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
+          go-version-file: go.mod
 
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
+      - name: Check formatting
+        run: |
+          unformatted="$(gofmt -l .)"
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            exit 1
+          fi
 
-          # Optional: golangci-lint command line arguments.
-          args: -E misspell -E revive -E errname -E gofmt
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
-
-          # Optional: if set to true then the action will use pre-installed Go.
-          # skip-go-installation: true
-
-          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
-          # skip-pkg-cache: true
-
-          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
-          # skip-build-cache: true
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
+        with:
+          version: v2.11
+          args: --enable=misspell --enable=revive --enable=errname

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
           config-file: .release-please-config.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Upload coverage reports to Codecov
         if: ${{ hashFiles('coverage.out') != '' }}
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: coverage.out
           flags: unittests

--- a/tasks.go
+++ b/tasks.go
@@ -222,6 +222,7 @@ type Task struct {
 	cancel context.CancelFunc
 }
 
+// TaskContext stores the user-defined context passed to task callbacks.
 type TaskContext struct {
 	// Context is a user-defined context.
 	Context context.Context


### PR DESCRIPTION
## Summary
Pins the current GitHub Actions updates by SHA and fixes the golangci-lint workflow for the current action/linter behavior. Dependabot can stop trying to trade tag bumps like baseball cards.

## Changes
- Updates lint workflow actions to pinned SHAs: `actions/checkout` v6, `actions/setup-go` v6, and `golangci/golangci-lint-action` v9.
- Pins the Dependabot-proposed `release-please-action` v5.0.0 and `codecov-action` v6.0.0 updates by SHA.
- Replaces floating `version: latest` with `version: v2.11` for golangci-lint.
- Moves `gofmt` out of golangci-lint `args` because v2 treats it as a formatter, not a linter.
- Adds the missing `TaskContext` doc comment required by `revive`.

## Validation
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }; puts "yaml ok"'`
- `gofmt -l .`
- `golangci-lint run --enable=misspell --enable=revive --enable=errname`
- `make tests`

## Risks
Low. The main behavior change is CI-only; the source change is a documentation comment for an exported type.