### PR TITLE
fix: make scheduler errors branchable

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -259,7 +259,7 @@ var (
 	ErrMissingTaskFunc = errors.New("task function cannot be nil")
 
 	// ErrInvalidInterval is returned when a task interval is not greater than zero.
-	ErrInvalidInterval = errors.New("task interval must be defined")
+	ErrInvalidInterval = errors.New("task interval must be greater than zero")
 
 	// ErrTaskNotFound is returned when a task ID does not exist in the scheduler.
 	ErrTaskNotFound = errors.New("task not found")

--- a/tasks.go
+++ b/tasks.go
@@ -256,7 +256,7 @@ var (
 	ErrIDInUse = errors.New("ID already used")
 
 	// ErrMissingTaskFunc is returned when a task has no executable callback.
-	ErrMissingTaskFunc = errors.New("task function cannot be nil")
+	ErrMissingTaskFunc = errors.New("either TaskFunc or FuncWithTaskContext must be provided")
 
 	// ErrInvalidInterval is returned when a task interval is not greater than zero.
 	ErrInvalidInterval = errors.New("task interval must be greater than zero")

--- a/tasks.go
+++ b/tasks.go
@@ -133,6 +133,7 @@ package tasks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -249,10 +250,19 @@ type Scheduler struct {
 
 var (
 	// ErrNilTask is returned when a nil task is provided to Add or AddWithID.
-	ErrNilTask = fmt.Errorf("task cannot be nil")
+	ErrNilTask = errors.New("task cannot be nil")
 
 	// ErrIDInUse is returned when a Task ID is specified but already used.
-	ErrIDInUse = fmt.Errorf("ID already used")
+	ErrIDInUse = errors.New("ID already used")
+
+	// ErrMissingTaskFunc is returned when a task has no executable callback.
+	ErrMissingTaskFunc = errors.New("task function cannot be nil")
+
+	// ErrInvalidInterval is returned when a task interval is not greater than zero.
+	ErrInvalidInterval = errors.New("task interval must be defined")
+
+	// ErrTaskNotFound is returned when a task ID does not exist in the scheduler.
+	ErrTaskNotFound = errors.New("task not found")
 )
 
 // New will create a new scheduler instance that allows users to create and manage tasks.
@@ -283,7 +293,7 @@ func New() *Scheduler {
 func (schd *Scheduler) Add(t *Task) (string, error) {
 	id := xid.New()
 	err := schd.AddWithID(id.String(), t)
-	if err == ErrIDInUse {
+	if errors.Is(err, ErrIDInUse) {
 		return schd.Add(t)
 	}
 	if err != nil {
@@ -318,12 +328,12 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 
 	// Check if TaskFunc is nil before doing anything
 	if t.TaskFunc == nil && t.FuncWithTaskContext == nil {
-		return fmt.Errorf("task function cannot be nil")
+		return ErrMissingTaskFunc
 	}
 
 	// Ensure Interval is never 0, this would cause Timer to panic
 	if t.Interval <= time.Duration(0) {
-		return fmt.Errorf("task interval must be defined")
+		return ErrInvalidInterval
 	}
 
 	// Check id is not in use, then add to task list and start background task
@@ -378,7 +388,7 @@ func (schd *Scheduler) Lookup(name string) (*Task, error) {
 	if ok {
 		return t.Clone(), nil
 	}
-	return t, fmt.Errorf("could not find task within the task list")
+	return t, fmt.Errorf("%w: %s", ErrTaskNotFound, name)
 }
 
 // Tasks is used to return a copy of the internal tasks map.

--- a/tasks.go
+++ b/tasks.go
@@ -331,7 +331,7 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 		return ErrMissingTaskFunc
 	}
 
-	// Ensure Interval is never 0, this would cause Timer to panic
+	// Ensure Interval is positive to avoid immediate firing and tight rescheduling.
 	if t.Interval <= time.Duration(0) {
 		return ErrInvalidInterval
 	}

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -2,6 +2,7 @@ package tasks
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -182,7 +183,7 @@ func TestTasksInterface(t *testing.T) {
 				t.Run(tc.name+" - Duplicate Task", func(t *testing.T) {
 					// Schedule the task
 					err := scheduler.AddWithID(tc.id, tc.task)
-					if err != ErrIDInUse {
+					if !errors.Is(err, ErrIDInUse) {
 						t.Errorf("Expected errors when scheduling a duplicate task")
 					}
 				})
@@ -406,24 +407,24 @@ func TestAdd(t *testing.T) {
 
 	t.Run("Add a nil task returns ErrNilTask", func(t *testing.T) {
 		id, err := scheduler.Add(nil)
-		if err != ErrNilTask {
+		if !errors.Is(err, ErrNilTask) {
 			t.Fatalf("expected ErrNilTask, got %v", err)
 		}
 		if id != "" {
 			t.Fatalf("expected empty ID for nil task, got %q", id)
 		}
-		if _, lookupErr := scheduler.Lookup(id); lookupErr == nil {
-			t.Fatalf("nil task should not be added to the scheduler")
+		if _, lookupErr := scheduler.Lookup(id); !errors.Is(lookupErr, ErrTaskNotFound) {
+			t.Fatalf("expected ErrTaskNotFound for nil task lookup, got %v", lookupErr)
 		}
 	})
 
 	t.Run("AddWithID a nil task returns ErrNilTask", func(t *testing.T) {
 		err := scheduler.AddWithID("nil-task", nil)
-		if err != ErrNilTask {
+		if !errors.Is(err, ErrNilTask) {
 			t.Fatalf("expected ErrNilTask, got %v", err)
 		}
-		if _, lookupErr := scheduler.Lookup("nil-task"); lookupErr == nil {
-			t.Fatalf("nil task should not be added to the scheduler")
+		if _, lookupErr := scheduler.Lookup("nil-task"); !errors.Is(lookupErr, ErrTaskNotFound) {
+			t.Fatalf("expected ErrTaskNotFound for nil task lookup, got %v", lookupErr)
 		}
 	})
 
@@ -494,7 +495,7 @@ func TestAdd(t *testing.T) {
 			TaskFunc: func() error { return nil },
 			ErrFunc:  func(_ error) {},
 		})
-		if err != ErrIDInUse {
+		if !errors.Is(err, ErrIDInUse) {
 			t.Errorf("Expected error for task with existing id")
 		}
 
@@ -521,7 +522,7 @@ func TestAdd(t *testing.T) {
 		}
 
 		err = scheduler.AddWithID(id, task)
-		if err != ErrIDInUse {
+		if !errors.Is(err, ErrIDInUse) {
 			t.Fatalf("Expected duplicate id error, got %v", err)
 		}
 
@@ -591,8 +592,8 @@ func TestAdd(t *testing.T) {
 			Interval: time.Duration(1 * time.Minute),
 			ErrFunc:  func(_ error) {},
 		})
-		if err == nil {
-			t.Errorf("Unexpected success when scheduling an invalid task - %s", err)
+		if !errors.Is(err, ErrMissingTaskFunc) {
+			t.Errorf("expected ErrMissingTaskFunc when scheduling an invalid task, got %v", err)
 		}
 	})
 
@@ -601,8 +602,15 @@ func TestAdd(t *testing.T) {
 			TaskFunc: func() error { return nil },
 			ErrFunc:  func(_ error) {},
 		})
-		if err == nil {
-			t.Errorf("Unexpected success when scheduling an invalid task - %s", err)
+		if !errors.Is(err, ErrInvalidInterval) {
+			t.Errorf("expected ErrInvalidInterval when scheduling an invalid task, got %v", err)
+		}
+	})
+
+	t.Run("Lookup missing task returns ErrTaskNotFound", func(t *testing.T) {
+		_, err := scheduler.Lookup("missing-task")
+		if !errors.Is(err, ErrTaskNotFound) {
+			t.Fatalf("expected ErrTaskNotFound, got %v", err)
 		}
 	})
 }

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -608,9 +609,13 @@ func TestAdd(t *testing.T) {
 	})
 
 	t.Run("Lookup missing task returns ErrTaskNotFound", func(t *testing.T) {
-		_, err := scheduler.Lookup("missing-task")
+		const missingID = "missing-task"
+		_, err := scheduler.Lookup(missingID)
 		if !errors.Is(err, ErrTaskNotFound) {
 			t.Fatalf("expected ErrTaskNotFound, got %v", err)
+		}
+		if !strings.Contains(err.Error(), missingID) {
+			t.Errorf("expected error message to contain task ID %q, got %q", missingID, err.Error())
 		}
 	})
 }


### PR DESCRIPTION
## Summary
Make scheduler error contracts durable and branchable with `errors.Is`.

## Changes
- Convert existing sentinel errors to `errors.New`.
- Add sentinels for missing task callbacks, invalid intervals, and missing task lookups.
- Wrap lookup misses with `ErrTaskNotFound` while retaining the missing task ID in the error text.
- Update tests to assert public error behavior with `errors.Is`.

## Validation
- `gofmt -w tasks.go tasks_test.go`
- `make tests`
- `go vet ./...`
- `make lint`

## Risks
- Low. API shape is unchanged, but callers that compare full error strings for lookup misses may see a different message. Error contracts now have less mystery meat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting for task scheduler operations including duplicate IDs, missing tasks, and invalid configurations.

* **Tests**
  * Enhanced test coverage for error handling scenarios in task operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->