### PR TITLE
fix: stop delayed start timers

### DIFF
--- a/tasks.go
+++ b/tasks.go
@@ -416,7 +416,18 @@ func (schd *Scheduler) Stop() {
 // scheduleTask creates the underlying scheduled task. If StartAfter is set, this routine will wait until the
 // time specified.
 func (schd *Scheduler) scheduleTask(t *Task) {
-	_ = time.AfterFunc(time.Until(t.StartAfter), func() {
+	delay := time.Until(t.StartAfter)
+	if delay <= 0 {
+		t.safeOps(func() {
+			if t.ctx.Err() != nil {
+				return
+			}
+			t.timer = time.AfterFunc(t.Interval, func() { schd.execTask(t) })
+		})
+		return
+	}
+
+	timer := time.AfterFunc(delay, func() {
 		var err error
 
 		// Verify if task has been cancelled before scheduling
@@ -432,6 +443,14 @@ func (schd *Scheduler) scheduleTask(t *Task) {
 		t.safeOps(func() {
 			t.timer = time.AfterFunc(t.Interval, func() { schd.execTask(t) })
 		})
+	})
+
+	t.safeOps(func() {
+		if t.ctx.Err() != nil {
+			timer.Stop()
+			return
+		}
+		t.timer = timer
 	})
 }
 

--- a/tasks.go
+++ b/tasks.go
@@ -428,19 +428,10 @@ func (schd *Scheduler) scheduleTask(t *Task) {
 	}
 
 	timer := time.AfterFunc(delay, func() {
-		var err error
-
-		// Verify if task has been cancelled before scheduling
 		t.safeOps(func() {
-			err = t.ctx.Err()
-		})
-		if err != nil {
-			// Task has been cancelled, do not schedule
-			return
-		}
-
-		// Schedule task
-		t.safeOps(func() {
+			if t.ctx.Err() != nil {
+				return
+			}
 			t.timer = time.AfterFunc(t.Interval, func() { schd.execTask(t) })
 		})
 	})

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -934,6 +934,59 @@ func TestSchedulerDoesntRun(t *testing.T) {
 	})
 }
 
+func TestStartAfterTimerLifecycle(t *testing.T) {
+	t.Run("Del stops delayed StartAfter timer", func(t *testing.T) {
+		scheduler := New()
+		defer scheduler.Stop()
+
+		id, err := scheduler.Add(&Task{
+			Interval:   testInterval,
+			StartAfter: time.Now().Add(time.Hour),
+			TaskFunc:   func() error { return nil },
+		})
+		if err != nil {
+			t.Fatalf("Unexpected errors when scheduling a valid task - %s", err)
+		}
+
+		task := scheduledTask(t, scheduler, id)
+		timer := taskTimer(t, task)
+
+		scheduler.Del(id)
+
+		if timer.Stop() {
+			t.Fatalf("expected Del to stop delayed StartAfter timer")
+		}
+		if _, err := scheduler.Lookup(id); !errors.Is(err, ErrTaskNotFound) {
+			t.Fatalf("expected deleted task lookup to return ErrTaskNotFound, got %v", err)
+		}
+	})
+
+	t.Run("Stop stops delayed StartAfter timer", func(t *testing.T) {
+		scheduler := New()
+
+		id, err := scheduler.Add(&Task{
+			Interval:   testInterval,
+			StartAfter: time.Now().Add(time.Hour),
+			TaskFunc:   func() error { return nil },
+		})
+		if err != nil {
+			t.Fatalf("Unexpected errors when scheduling a valid task - %s", err)
+		}
+
+		task := scheduledTask(t, scheduler, id)
+		timer := taskTimer(t, task)
+
+		scheduler.Stop()
+
+		if timer.Stop() {
+			t.Fatalf("expected Stop to stop delayed StartAfter timer")
+		}
+		if _, err := scheduler.Lookup(id); !errors.Is(err, ErrTaskNotFound) {
+			t.Fatalf("expected stopped task lookup to return ErrTaskNotFound, got %v", err)
+		}
+	})
+}
+
 func TestSchedulerExtras(t *testing.T) {
 	// Create a base scheduler to use
 	scheduler := New()
@@ -1063,4 +1116,29 @@ func TestSingleInstance(t *testing.T) {
 			t.Fatalf("Task was not called more than once successfully - count %d", counter2.Val())
 		}
 	}
+}
+
+func scheduledTask(t *testing.T, scheduler *Scheduler, id string) *Task {
+	t.Helper()
+
+	scheduler.RLock()
+	defer scheduler.RUnlock()
+
+	task, ok := scheduler.tasks[id]
+	if !ok {
+		t.Fatalf("expected scheduler to contain task %q", id)
+	}
+	return task
+}
+
+func taskTimer(t *testing.T, task *Task) *time.Timer {
+	t.Helper()
+
+	task.RLock()
+	defer task.RUnlock()
+
+	if task.timer == nil {
+		t.Fatalf("expected scheduled task to have a timer")
+	}
+	return task.timer
 }


### PR DESCRIPTION
## Summary
Tighten scheduler lifecycle handling for delayed `StartAfter` tasks.

## Changes
- Store future `StartAfter` timers in scheduler-owned task state.
- Let existing `Del` and `Stop` paths stop delayed timers immediately.
- Preserve current behavior for already-running callbacks: deletion prevents future invocations but does not interrupt active task work.
- Add tests proving `Del` and `Stop` stop delayed `StartAfter` timers and remove tasks from lookup.

## Validation
- `go test ./...`
- `go test -race ./...`
- `make tests`
- `go vet ./...`
- `make lint`
- `make benchmarks`
- `git diff --check`

## Risks
- Low. This changes timer ownership for delayed starts, so CI race checks are the important signal. The scheduler now holds onto its alarm clock instead of tossing it under the couch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task cancellation for delayed-start scheduling to prevent timer leaks and ensure proper cleanup when tasks are deleted or stopped.

* **Tests**
  * Added test coverage for delayed-start task cancellation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/madflojo/tasks/pull/37)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->