### PR TITLE
docs: clarify scheduler lifecycle and README pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ that long execution of a single invocation does not throw the schedule as a whol
 For simplicity this task scheduler uses the time.Duration type to specify intervals. This allows for a simple interface 
 and flexible control over when tasks are executed.
 
+Calling `Del` or `Stop` prevents delayed or future invocations, including tasks waiting on `StartAfter`. These methods do
+not interrupt task functions that have already started.
+
 ## Key Features
 
 - **Concurrent Execution**: Tasks are executed in their own goroutines, ensuring accurate scheduling even when individual tasks take longer to complete.
@@ -26,6 +29,16 @@ and flexible control over when tasks are executed.
 - **Task Context Support**: Pass user-defined context and task metadata into callbacks with `FuncWithTaskContext`, `ErrFuncWithTaskContext`, and `TaskContext.ID()`.
 - **Custom Error Handling**: Define a custom error handling function to handle errors returned by tasks, enabling tailored error handling logic.
 - **Custom Task IDs**: Provide your own task IDs with `AddWithID` when you need deterministic identifiers.
+
+## Error Handling
+
+Scheduler validation and lookup errors are exposed as sentinel errors so callers can branch with `errors.Is`:
+
+- `ErrNilTask`
+- `ErrIDInUse`
+- `ErrMissingTaskFunc`
+- `ErrInvalidInterval`
+- `ErrTaskNotFound`
 
 ## Usage
 
@@ -54,7 +67,8 @@ if err != nil {
 ### Delayed Scheduling
 
 Sometimes schedules need to started at a later time. This package provides the ability to start a task only after a 
-certain time. The below example shows this in practice.
+certain time. The below example shows this in practice. Deleting the task or stopping the scheduler before `StartAfter`
+prevents the delayed run from being scheduled.
 
 ```go
 // Add a recurring task for every 30 days, starting 30 days from now
@@ -96,6 +110,8 @@ if err != nil {
 One powerful feature of Tasks is that it allows users to specify custom error handling. This is done by allowing users 
 to define a function that is called when a task returns an error. The below example shows scheduling a task that logs 
 when an error occurs.
+
+If both `ErrFunc` and `ErrFuncWithTaskContext` are set, `ErrFuncWithTaskContext` is used.
 
 ```go
 // Add a task with custom error handling

--- a/README.md
+++ b/README.md
@@ -2,33 +2,38 @@
 
 [![tests](https://github.com/madflojo/tasks/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/madflojo/tasks/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/madflojo/tasks/graph/badge.svg?token=882QTXA7PX)](https://codecov.io/gh/madflojo/tasks)
-[![Go Report Card](https://goreportcard.com/badge/github.com/madflojo/tasks)](https://goreportcard.com/report/github.com/madflojo/tasks) 
+[![Go Report Card](https://goreportcard.com/badge/github.com/madflojo/tasks)](https://goreportcard.com/report/github.com/madflojo/tasks)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/madflojo/tasks)](https://pkg.go.dev/github.com/madflojo/tasks)
 
-Package tasks is an easy to use in-process scheduler for recurring tasks in Go. Tasks is focused on high frequency
-tasks that run quick, and often. The goal of Tasks is to support concurrent running tasks at scale without scheduler
-induced jitter.
+A small in-process scheduler for Go tasks that need to run on time.
 
-Tasks is focused on accuracy of task execution. To do this each task is called within it's own goroutine. This ensures 
-that long execution of a single invocation does not throw the schedule as a whole off track.
+Tasks is built for recurring, quick-running jobs where scheduler-induced jitter needs to stay low and the scheduler
+should stay out of the way. Each invocation runs in its own goroutine, so one slow task does not make the whole schedule
+trip over its shoelaces.
 
-For simplicity this task scheduler uses the time.Duration type to specify intervals. This allows for a simple interface 
-and flexible control over when tasks are executed.
+Use Tasks when you want recurring work without cron wiring, a worker fleet, or a pile of scheduling boilerplate.
+It is an in-process scheduler, not a durable queue or distributed job runner; if your process exits, your schedule exits
+with it. That tradeoff keeps the package small, fast, and easy to reason about.
+
+## Install
+
+```bash
+go get github.com/madflojo/tasks
+```
+
+## Why Tasks
+
+- **Accurate recurring execution**: Each invocation runs independently, so a long-running task does not block unrelated schedules.
+- **Small API**: Intervals use Go's `time.Duration`; no custom cron language required.
+- **Delayed and one-time runs**: Use `StartAfter` and `RunOnce` for jobs that should begin later or run just once.
+- **Overlap control**: Use `RunSingleInstance` to skip a run when the previous invocation is still working. No dogpiling.
+- **Task context support**: Pass user-defined context and task metadata into callbacks with `FuncWithTaskContext`, `ErrFuncWithTaskContext`, and `TaskContext.ID()`.
+- **Stable IDs and branchable errors**: Use `AddWithID` for deterministic identifiers and `errors.Is` for scheduler errors.
+
+## Lifecycle Guarantees
 
 Calling `Del` or `Stop` prevents delayed or future invocations, including tasks waiting on `StartAfter`. These methods do
-not interrupt task functions that have already started.
-
-## Key Features
-
-- **Concurrent Execution**: Tasks are executed in their own goroutines, ensuring accurate scheduling even when individual tasks take longer to complete.
-- **Optimized Goroutine Scheduling**: Tasks leverages Go's `time.AfterFunc()` function to reduce sleeping goroutines and optimize CPU scheduling.
-- **Flexible Task Intervals**: Tasks uses the `time.Duration` type to specify intervals, offering a simple interface and flexible control over task execution timing.
-- **Delayed Task Start**: Schedule tasks to start at a later time by specifying a start time, allowing for greater control over task execution.
-- **One-Time Tasks**: Schedule tasks to run only once by setting the `RunOnce` flag, ideal for single-use tasks or one-time actions.
-- **Single-Instance Tasks**: Prevent overlapping runs by setting `RunSingleInstance`, which skips a run if the previous invocation is still executing.
-- **Task Context Support**: Pass user-defined context and task metadata into callbacks with `FuncWithTaskContext`, `ErrFuncWithTaskContext`, and `TaskContext.ID()`.
-- **Custom Error Handling**: Define a custom error handling function to handle errors returned by tasks, enabling tailored error handling logic.
-- **Custom Task IDs**: Provide your own task IDs with `AddWithID` when you need deterministic identifiers.
+not interrupt task functions that have already started; once your callback is running, it gets to finish its lap.
 
 ## Error Handling
 
@@ -40,9 +45,15 @@ Scheduler validation and lookup errors are exposed as sentinel errors so callers
 - `ErrInvalidInterval`
 - `ErrTaskNotFound`
 
+```go
+if errors.Is(err, tasks.ErrIDInUse) {
+  // Pick another ID or update the existing task.
+}
+```
+
 ## Usage
 
-Here are some examples to help you get started with Tasks:
+Here are some examples to help you get Tasks doing useful work without much ceremony.
 
 ### Basic Usage
 
@@ -60,15 +71,15 @@ id, err := scheduler.Add(&tasks.Task{
   },
 })
 if err != nil {
-  // Do Stuff
+  // Handle error
 }
 ```
 
 ### Delayed Scheduling
 
-Sometimes schedules need to started at a later time. This package provides the ability to start a task only after a 
-certain time. The below example shows this in practice. Deleting the task or stopping the scheduler before `StartAfter`
-prevents the delayed run from being scheduled.
+Sometimes schedules need to start later, not right now with a tiny starter pistol. Set `StartAfter` to delay the start
+of a task's interval schedule. Deleting the task or stopping the scheduler before `StartAfter` prevents the delayed run
+from being scheduled.
 
 ```go
 // Add a recurring task for every 30 days, starting 30 days from now
@@ -81,17 +92,16 @@ id, err := scheduler.Add(&tasks.Task{
   },
 })
 if err != nil {
-  // Do Stuff
+  // Handle error
 }
 ```
 
 ### One-Time Tasks
 
-It is also common for applications to run a task only once. The below example shows scheduling a task to run only once 
-after waiting for 60 seconds.
+Some jobs only need one lap. The example below schedules a task to run once after waiting for 60 seconds.
 
 ```go
-// Add a one time only task for 60 seconds from now
+// Add a one-time task for 60 seconds from now
 id, err := scheduler.Add(&tasks.Task{
   Interval: 60 * time.Second,
   RunOnce:  true,
@@ -101,15 +111,14 @@ id, err := scheduler.Add(&tasks.Task{
   },
 })
 if err != nil {
-  // Do Stuff
+  // Handle error
 }
 ```
 
 ### Custom Error Handling
 
-One powerful feature of Tasks is that it allows users to specify custom error handling. This is done by allowing users 
-to define a function that is called when a task returns an error. The below example shows scheduling a task that logs 
-when an error occurs.
+Tasks lets callers define custom error handling with a callback that runs when a task returns an error. The example
+below schedules a task that logs when things go sideways.
 
 If both `ErrFunc` and `ErrFuncWithTaskContext` are set, `ErrFuncWithTaskContext` is used.
 
@@ -126,13 +135,14 @@ id, err := scheduler.Add(&tasks.Task{
   },
 })
 if err != nil {
-  // Do Stuff
+  // Handle error
 }
 ```
 
 ### Single-Instance Tasks
 
 Use `RunSingleInstance` when a task might take longer than its interval and overlapping executions should be skipped.
+No dogpiling, no duplicate workers stepping on each other.
 
 ```go
 id, err := scheduler.Add(&tasks.Task{
@@ -144,7 +154,7 @@ id, err := scheduler.Add(&tasks.Task{
   },
 })
 if err != nil {
-  // Do Stuff
+  // Handle error
 }
 ```
 
@@ -167,13 +177,14 @@ id, err := scheduler.Add(&tasks.Task{
   },
 })
 if err != nil {
-  // Do Stuff
+  // Handle error
 }
 ```
 
 ### Custom Task IDs
 
-Use `AddWithID` when you want to provide your own stable identifier for a task.
+Use `AddWithID` when you want to provide your own stable identifier for a task. Handy when "whatever ID the scheduler
+picked" is not quite descriptive enough for future you.
 
 ```go
 err := scheduler.AddWithID("nightly-report", &tasks.Task{
@@ -184,7 +195,7 @@ err := scheduler.AddWithID("nightly-report", &tasks.Task{
   },
 })
 if err != nil {
-  // Do Stuff
+  // Handle error
 }
 ```
 

--- a/tasks.go
+++ b/tasks.go
@@ -178,8 +178,8 @@ type Task struct {
 	// of the same task from running concurrently.
 	RunSingleInstance bool
 
-	// StartAfter is used to specify a start time for the scheduler. When set, tasks will wait for the specified
-	// time to start the schedule timer.
+	// StartAfter is used to specify when the task's interval schedule starts. When set to a future time, the task waits
+	// until StartAfter before starting its recurring interval timer.
 	StartAfter time.Time
 
 	// TaskFunc is the user defined function to execute as part of this task.
@@ -187,8 +187,8 @@ type Task struct {
 	// Either TaskFunc or FuncWithTaskContext must be defined. If both are defined, FuncWithTaskContext will be used.
 	TaskFunc func() error
 
-	// ErrFunc allows users to define a function that is called when tasks return an error. If ErrFunc is nil,
-	// errors from tasks will be ignored.
+	// ErrFunc allows users to define a function that is called when tasks return an error. If ErrFunc and
+	// ErrFuncWithTaskContext are nil, errors from tasks will be ignored.
 	//
 	// Either ErrFunc or ErrFuncWithTaskContext must be defined. If both are defined, ErrFuncWithTaskContext will be used.
 	ErrFunc func(error)
@@ -200,8 +200,8 @@ type Task struct {
 	FuncWithTaskContext func(TaskContext) error
 
 	// ErrFuncWithTaskContext allows users to define a function that is called when tasks return an error.
-	// If ErrFunc is nil, errors from tasks will be ignored. This function is used in place of ErrFunc with
-	// the difference in that it will pass the user defined context from the Task configurations.
+	// If ErrFunc and ErrFuncWithTaskContext are nil, errors from tasks will be ignored. This function is used in place
+	// of ErrFunc with the difference in that it will pass the user defined context from the Task configurations.
 	//
 	// Either ErrFunc or ErrFuncWithTaskContext must be defined. If both are defined, ErrFuncWithTaskContext will be used.
 	ErrFuncWithTaskContext func(TaskContext, error)
@@ -302,7 +302,7 @@ func (schd *Scheduler) Add(t *Task) (string, error) {
 	return id.String(), nil
 }
 
-// AddWithID will add a task with an ID to the task list and schedule it. It will return an error if the ID is in-use.
+// AddWithID will add a task with an ID to the task list and schedule it. It will return ErrIDInUse if the ID is in-use.
 // Once added, tasks will wait the defined time interval and then execute. This means a task with a 15 second interval
 // will be triggered 15 seconds after Add is complete. Not before or after (excluding typical machine time jitter).
 //
@@ -352,8 +352,8 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 	return nil
 }
 
-// Del will unschedule the specified task and remove it from the task list. Deletion will prevent future invocations of
-// a task, but not interrupt a triggered task.
+// Del will unschedule the specified task and remove it from the task list. Deletion stops delayed or future
+// invocations of a task, but does not interrupt a task function that has already started.
 func (schd *Scheduler) Del(name string) {
 	schd.Lock()
 	t, ok := schd.tasks[name]
@@ -377,7 +377,8 @@ func (schd *Scheduler) Del(name string) {
 	}
 }
 
-// Lookup will find the specified task from the internal task list using the task ID provided.
+// Lookup will find the specified task from the internal task list using the task ID provided. It returns
+// ErrTaskNotFound when no task exists for the ID.
 //
 // The returned task is a copy of the scheduled task configuration. Scheduler-owned runtime state is intentionally
 // excluded from the returned task.
@@ -405,7 +406,8 @@ func (schd *Scheduler) Tasks() map[string]*Task {
 	return m
 }
 
-// Stop is used to unschedule and delete all tasks owned by the scheduler instance.
+// Stop is used to unschedule and delete all tasks owned by the scheduler instance. Stop prevents delayed or future
+// invocations, but does not interrupt task functions that have already started.
 func (schd *Scheduler) Stop() {
 	tt := schd.Tasks()
 	for n := range tt {

--- a/tasks_benchmarks_test.go
+++ b/tasks_benchmarks_test.go
@@ -27,24 +27,17 @@ func BenchmarkTasks(b *testing.B) {
 		b.Fatalf("Unable to lookup newly added task - %s", err)
 	}
 
-	b.Run("Adding a scheduler", func(b *testing.B) {
+	b.Run("Adding and deleting a scheduled task", func(b *testing.B) {
 		b.ReportAllocs()
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			_, err := scheduler.Add(exampleTask)
+			id, err := scheduler.Add(exampleTask)
 			if err != nil {
 				b.Fatalf("Unable to add new scheduled task - %s", err)
 			}
+			scheduler.Del(id)
 		}
 	})
-
-	// Clear Excess Tasks
-	for id := range scheduler.Tasks() {
-		if id == taskID {
-			continue
-		}
-		scheduler.Del(id)
-	}
 
 	b.Run("Looking up a scheduled task", func(b *testing.B) {
 		b.ReportAllocs()


### PR DESCRIPTION
## Summary
Tighten the Stage 4 docs pass so lifecycle behavior is explicit and the README gives new users a clearer path from "what is this?" to "how do I use it?". A little scheduler polish, no yak required.

## Changes
- Clarify scheduler lifecycle contracts for delayed starts, deletion, stopping, callback precedence, and lookup behavior.
- Update benchmark cleanup to avoid accumulating scheduled timers during repeated additions.
- Rework the README opening, install path, benefits, lifecycle guarantees, and sentinel error guidance.

## Validation
- `go test ./...`
- `git diff --check`

## Risks
- Low risk; changes are documentation-focused with one benchmark cleanup adjustment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and enhanced README with expanded Install instructions, "Why Tasks" feature highlights, Lifecycle Guarantees, and Error Handling sections. Added Go Report Card and PkgGoDev badges.
  * Clarified scheduler behavior documentation in method docstrings.

* **Tests**
  * Updated benchmark to measure add-and-delete task operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/madflojo/tasks/pull/38)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->