### PR TITLE
fix: reject empty custom task IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Scheduler validation and lookup errors are exposed as sentinel errors so callers
 
 - `ErrNilTask`
 - `ErrIDInUse`
+- `ErrInvalidID`
 - `ErrMissingTaskFunc`
 - `ErrInvalidInterval`
 - `ErrTaskNotFound`

--- a/tasks.go
+++ b/tasks.go
@@ -259,6 +259,9 @@ var (
 	// ErrIDInUse is returned when a Task ID is specified but already used.
 	ErrIDInUse = errors.New("ID already used")
 
+	// ErrInvalidID is returned when AddWithID is called with an empty ID.
+	ErrInvalidID = errors.New("task ID cannot be empty")
+
 	// ErrMissingTaskFunc is returned when a task has no executable callback.
 	ErrMissingTaskFunc = errors.New("either TaskFunc or FuncWithTaskContext must be provided")
 
@@ -309,9 +312,10 @@ func (schd *Scheduler) Add(t *Task) (string, error) {
 	return id.String(), nil
 }
 
-// AddWithID will add a task with an ID to the task list and schedule it. It will return ErrIDInUse if the ID is in-use.
-// Once added, tasks will wait the defined time interval and then execute. This means a task with a 15 second interval
-// will be triggered 15 seconds after Add is complete. Not before or after (excluding typical machine time jitter).
+// AddWithID will add a task with an ID to the task list and schedule it. It will return ErrInvalidID if the ID is empty
+// or ErrIDInUse if the ID is in-use. Once added, tasks will wait the defined time interval and then execute. This means
+// a task with a 15 second interval will be triggered 15 seconds after Add is complete. Not before or after (excluding
+// typical machine time jitter).
 //
 //	// Add a task
 //	id := xid.New()
@@ -341,6 +345,10 @@ func (schd *Scheduler) AddWithID(id string, t *Task) error {
 	// Ensure Interval is positive to avoid immediate firing and tight rescheduling.
 	if t.Interval <= time.Duration(0) {
 		return ErrInvalidInterval
+	}
+
+	if id == "" {
+		return ErrInvalidID
 	}
 
 	// Check id is not in use, then add to task list and start background task

--- a/tasks_test.go
+++ b/tasks_test.go
@@ -549,6 +549,27 @@ func TestAdd(t *testing.T) {
 
 	})
 
+	t.Run("AddWithID empty id returns ErrInvalidID without scheduling task", func(t *testing.T) {
+		scheduler := New()
+		defer scheduler.Stop()
+
+		err := scheduler.AddWithID("", &Task{
+			Interval: time.Minute,
+			TaskFunc: func() error { return nil },
+		})
+		if !errors.Is(err, ErrInvalidID) {
+			t.Fatalf("expected ErrInvalidID, got %v", err)
+		}
+
+		if tasks := scheduler.Tasks(); len(tasks) != 0 {
+			t.Fatalf("expected no scheduled tasks, got %d", len(tasks))
+		}
+
+		if _, err := scheduler.Lookup(""); !errors.Is(err, ErrTaskNotFound) {
+			t.Fatalf("expected Lookup(\"\") to return ErrTaskNotFound, got %v", err)
+		}
+	})
+
 	t.Run("Add a invalid task with an duplicate id and look it up", func(t *testing.T) {
 		// Setup A task
 		id, err := scheduler.Add(&Task{


### PR DESCRIPTION
## Summary
Reject empty custom task IDs in `AddWithID` with a new exported `ErrInvalidID` sentinel.

## Changes
- Add `ErrInvalidID` for empty custom IDs.
- Preserve existing validation order and keep arbitrary non-empty IDs valid.
- Document the new sentinel in README and Go docs.
- Add focused coverage for `AddWithID("", task)` and `Lookup("")` behavior.

## Validation
- `make tests`
- `make lint`

## Risks
- Intentional behavior change only for callers using `AddWithID("", task)`. No format validation beyond empty strings.